### PR TITLE
Add MacOS STEAM cloud World saves path

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,9 @@
             <strong>MacOS</strong>: ~/Library/Application
             Support/Terraria/Worlds
           </li>
+          <li>
+            <strong>MacOS (STEAM cloud)</strong>: ~/Library/Application Support/Steam/userdata/{YOUR_USER_ID}/105600/remote/worlds
+          </li>
           <li><strong>Linux</strong>: ~/.local/share/Terraria/Worlds</li>
         </ul>
       </ol>


### PR DESCRIPTION
I always find it difficult to find the Steam cloud World save paths for MacOS, so just adding it to the list of paths of the index.html file :)