### PR TITLE
Add missing vines and thorns for crimson/corruption blocks sets

### DIFF
--- a/resources/js/sets.js
+++ b/resources/js/sets.js
@@ -33,6 +33,11 @@ var sets = [
         "isTile": true
       },
       {
+        "Id": "352",
+        "Name": "Crimtane Thorns",
+        "isTile": true
+      },
+      {
         "Id": "399",
         "Name": "Crimson Hardened Sand",
         "isTile": true
@@ -64,7 +69,7 @@ var sets = [
       },
       {
         "Id": "32",
-        "Name": "Corrupted Vines",
+        "Name": "Corruption Thorns",
         "isTile": true
       },
       {
@@ -85,6 +90,11 @@ var sets = [
       {
         "Id": "400",
         "Name": "Corrupt Sandstone",
+        "isTile": true
+      },
+      {
+        "Id": "636",
+        "Name": "Corrupt Vines",
         "isTile": true
       }
     ]


### PR DESCRIPTION
Originally both crimson and corruption blocks sets only contained vines and not thorns, and "Corrupted Vines" block id was that of corruption thorns, so crimson and corruption blocks sets actually contained different sets of blocks. 

And if crimson/corruption blocks sets were intended for searching the blocks needed to be removed in order to make the world pure, the sets were incomplete as both crimson/corruption thorns and (probably) vines all count as blocks of their respective biomes and affect the world purity, and neither set contained both vines and thorns.

The fact that corruptions blocks set was missing corrupt vines (and instead contained corruption thorns) is probably not a big issue, as crimson/corruption vines can only grow on the grass blocks of the corresponding biome. But crimson blocks set not containing crimtane thorns is actually a problem because the thorns can be located anywhere and are hard to spot, and just a few (maybe even one) thorn block is enough to render the world as being 1% crimson.