### PR TITLE
Add set for item-summoning statues

### DIFF
--- a/resources/js/sets.js
+++ b/resources/js/sets.js
@@ -195,5 +195,25 @@ var sets = [
         "isItem": true
       }
     ]
-  }
+  },
+  {
+    "Name": "Item-summoning statues",
+    "Entries": [
+      {
+        "Id": "473",
+        "Name": "Heart Statue",
+        "isItem": true
+      },
+      {
+        "Id": "438",
+        "Name": "Star Statue",
+        "isTile": true
+      },
+      {
+        "Id": "453",
+        "Name": "Bomb Statue",
+        "isItem": true
+      },
+    ]
+  }  
 ]


### PR DESCRIPTION
Dear author of the super-useful online TerraMap,

With this Pull Request I suggest to add a set called 'Item spawning statues', which is the same set as <https://terraria-archive.fandom.com/wiki/Statues#Item_Spawning_Statues>. I don't know how to test this, but hey, I did take good care when writing the code :-)

This PR would save me and my girlfriend a lot of time hunting for these statues :-)

Cheers, Richel Bilderbeek

