### PR TITLE
Fix load failure on shimmered NPCs and incorrect shimmer color

### DIFF
--- a/resources/js/WorldLoader.js
+++ b/resources/js/WorldLoader.js
@@ -656,7 +656,7 @@ function readNpcs(reader, world) {
     if (world.version >= 268) {
         let num = reader.readInt32();
         while(num-- > 0) {
-            reader.readint32();
+            reader.readInt32();
         }
     }
 
@@ -687,7 +687,7 @@ function readNpcs(reader, world) {
     flag = reader.readUint8() > 0;
     while (flag) {
         npc = {};
-        reader.readint32();
+        reader.readInt32();
         npc.type = readString(reader);
         npc.x = reader.readFloat32();
         npc.y = reader.readFloat32();

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -1006,6 +1006,8 @@ function getTileColor(y, tile, world) {
       return liquidColors[1];
     else if (tile.IsLiquidHoney)
       return liquidColors[2];
+    else if (tile.Shimmer)
+      return { "r": 155, "g": 112, "b": 233 };
     else
       return liquidColors[0];
   }


### PR DESCRIPTION
Displays purple instead of blue for shimmer pools.  Fixes invalid function call when reading a world containing shimmered town NPCs.